### PR TITLE
Making compatible with pydantic parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ name = "plugnparse"  # REQUIRED, is the only field that cannot be marked as dyna
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.2.1"  # REQUIRED, although can be dynamic
+version = "0.2.2"  # REQUIRED, although can be dynamic
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/src/plugnparse/plugin.py
+++ b/src/plugnparse/plugin.py
@@ -339,22 +339,22 @@ class Plugin(metaclass=abc.ABCMeta):
             module_name = parameters.get(plugin_module_property_name)
         else:
             # --- ensure the parameters object has a property holding the plugin class name ---
-            if not hasattr(type(parameters), plugin_property_name):
+            try:
+                # --- assign the class name from the parameters ---
+                class_name = getattr(parameters, plugin_property_name)
+            except:
                 logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
                                      plugin_property_name, "] from parameters object [", type(parameters),
                                      "]. Unable to generate Plugin!")
 
-            # --- assign the class name from the parameters ---
-            class_name = getattr(parameters, plugin_property_name)
-
             # --- ensure the parameters object has a property holding the plugin module name ---
-            if not hasattr(type(parameters), plugin_module_property_name):
+            try:
+                # --- assign the module name from the parameters ---
+                module_name = getattr(parameters, plugin_module_property_name)
+            except:
                 logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
                                      plugin_module_property_name, "] from parameters object [", type(parameters),
                                      "]. Unable to generate Plugin!")
-
-            # --- assign the module name from the parameters ---
-            module_name = getattr(parameters, plugin_module_property_name)
 
         return class_name, module_name
 


### PR DESCRIPTION
## Problem
This always returns false for parameters with a pydantic base model class
```python
hasattr(type(parameters), parameter_name)
```
Which means you cannot use `construct_from_parameters` like so:
```python
parameters = DataModuleParameters(
    dataset_type="DatasetType",
    dataset_module="dataset_module"
)

Dataset.construct_from_parameters(parameters)
```