### PR TITLE
Account for parameterized type/module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ name = "plugnparse"  # REQUIRED, is the only field that cannot be marked as dyna
 #
 # For a discussion on single-sourcing the version, see
 # https://packaging.python.org/guides/single-sourcing-package-version/
-version = "0.2.2"  # REQUIRED, although can be dynamic
+version = "0.2.3"  # REQUIRED, although can be dynamic
 
 # This is a one-line description or tagline of what your project does. This
 # corresponds to the "Summary" metadata field:

--- a/src/plugnparse/plugin.py
+++ b/src/plugnparse/plugin.py
@@ -343,18 +343,26 @@ class Plugin(metaclass=abc.ABCMeta):
                 # --- assign the class name from the parameters ---
                 class_name = getattr(parameters, plugin_property_name)
             except:
-                logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
-                                     plugin_property_name, "] from parameters object [", type(parameters),
-                                     "]. Unable to generate Plugin!")
+                if hasattr(parameters, "parameterized_type"):
+                    # --- assign the class name from the parameterized type ---
+                    class_name = parameters.parameterized_type
+                else:
+                    logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
+                                         plugin_property_name, "] from parameters object [", type(parameters),
+                                         "]. Unable to generate Plugin!")
 
             # --- ensure the parameters object has a property holding the plugin module name ---
             try:
                 # --- assign the module name from the parameters ---
                 module_name = getattr(parameters, plugin_module_property_name)
             except:
-                logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
-                                     plugin_module_property_name, "] from parameters object [", type(parameters),
-                                     "]. Unable to generate Plugin!")
+                if hasattr(parameters, "parameterized_module"):
+                    # --- assign the class name from the parameterized module ---
+                    module_name = parameters.parameterized_module
+                else:
+                    logger.log_and_raise(RuntimeError, "Unable to extract plugin property name [",
+                                         plugin_module_property_name, "] from parameters object [", type(parameters),
+                                         "]. Unable to generate Plugin!")
 
         return class_name, module_name
 


### PR DESCRIPTION
## Changes
Updates to handle parameterized type and module

## Integration testing
These changes were used in the integration testing described in https://github.com/orthly/orthlyml/pull/339

## Details
Constructing from parameters needs to handle three cases

1. Legacy parameters
2. Parameterized types/modules (DataModule in the example below)
3. Non-parameterized types/modules (Dataset in the example below)

```python
class DataModuleParameters(Parameters):
    """Example parameters for DataModule."""

    parameterized_module: str | None = Field(
        default=None,
        description="Module of the parameterized class "
        "(e.g. orthlyml.applications.crown_generation.models.crown_generation_model)",
    )
    parameterized_type: str | None = Field(
        default=None, description="The type of the parameterized class (e.g. CrownGenerationModel)"
    )

    dataset_type: str | None = pydantic.Field(
        default=None,
        description="Name of the Dataset subclass to use for training.",
    )
    dataset_module: str | None = pydantic.Field(
        default=None,
        description="Module path to the Dataset subclass (e.g., orthlyml.foo.bar).",
    )
```

```python
data_module_parameters = DataModuleParameters(
    parameterized_module="data_module",
    parameterized_type="DataModule",
    dataset_type="Dataset",
    dataset_module="dataset_module",
)

Dataset.construct_from_parameters(data_module_parameters)

DataModule.construct_from_parameters(data_module_parameters, data_module_parameters=data_module_parameters)
```